### PR TITLE
operations interfaces

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,7 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -23,7 +23,7 @@ repositories {
 
 dependencies {
     compile(kotlin("stdlib"))
-    compile("io.titandata:remote-sdk:0.0.10")
+    compile("io.titandata:remote-sdk:0.0.11")
     compile("software.amazon.awssdk:auth:2.7.33")
     testImplementation("io.mockk:mockk:1.9.3")
     testImplementation("io.kotlintest:kotlintest-runner-junit5:3.4.2")

--- a/client/build.gradle.kts
+++ b/client/build.gradle.kts
@@ -1,3 +1,7 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
 plugins {
     kotlin("jvm")
     jacoco
@@ -5,7 +9,9 @@ plugins {
     `maven-publish`
 
 }
+
 repositories {
+    mavenLocal()
     mavenCentral()
     jcenter()
     maven("https://dl.bintray.com/kotlin/kotlinx")
@@ -17,7 +23,7 @@ repositories {
 
 dependencies {
     compile(kotlin("stdlib"))
-    compile("io.titandata:remote-sdk:0.0.8")
+    compile("io.titandata:remote-sdk:0.0.10")
     compile("software.amazon.awssdk:auth:2.7.33")
     testImplementation("io.mockk:mockk:1.9.3")
     testImplementation("io.kotlintest:kotlintest-runner-junit5:3.4.2")

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -22,7 +22,7 @@ repositories {
 
 dependencies {
     compile(kotlin("stdlib"))
-    compile("io.titandata:remote-sdk:0.0.10")
+    compile("io.titandata:remote-sdk:0.0.11")
     compile("com.google.code.gson:gson:2.8.6")
     compile("com.amazonaws:aws-java-sdk-s3:1.11.668")
     compile("javax.xml.bind:jaxb-api:2.3.1")

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -1,3 +1,7 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
 plugins {
     kotlin("jvm")
     jacoco
@@ -6,6 +10,7 @@ plugins {
 
 }
 repositories {
+    mavenLocal()
     mavenCentral()
     jcenter()
     maven("https://dl.bintray.com/kotlin/kotlinx")
@@ -17,7 +22,7 @@ repositories {
 
 dependencies {
     compile(kotlin("stdlib"))
-    compile("io.titandata:remote-sdk:0.0.8")
+    compile("io.titandata:remote-sdk:0.0.10")
     compile("com.google.code.gson:gson:2.8.6")
     compile("com.amazonaws:aws-java-sdk-s3:1.11.668")
     compile("javax.xml.bind:jaxb-api:2.3.1")

--- a/server/src/main/kotlin/io/titandata/remote/s3/server/S3RemoteServer.kt
+++ b/server/src/main/kotlin/io/titandata/remote/s3/server/S3RemoteServer.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
 package io.titandata.remote.s3.server
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider
@@ -6,13 +10,17 @@ import com.amazonaws.auth.BasicSessionCredentials
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.amazonaws.services.s3.model.AmazonS3Exception
+import com.amazonaws.services.s3.model.ObjectMetadata
+import com.amazonaws.services.s3.model.PutObjectRequest
 import com.google.gson.GsonBuilder
 import com.google.gson.reflect.TypeToken
 import io.titandata.remote.RemoteOperation
-import io.titandata.remote.RemoteServer
 import io.titandata.remote.RemoteServerUtil
+import io.titandata.remote.archive.ArchiveRemote
 import java.io.ByteArrayInputStream
+import java.io.File
 import java.io.InputStream
+import java.io.SequenceInputStream
 
 /**
  * The S3 provider is a very simple provider for storing whole commits directly in a S3 bucket. Each commit is is a
@@ -33,7 +41,7 @@ import java.io.InputStream
  * concurrent operations creating invalid state, but those are existing challenges with these simplistic providers.
  * Properly solving them would require a more sophisticated provider with server-side logic.
  */
-class S3RemoteServer : RemoteServer {
+class S3RemoteServer : ArchiveRemote() {
 
     private val METADATA_PROP = "io.titan-data"
     internal val gson = GsonBuilder().create()
@@ -193,15 +201,96 @@ class S3RemoteServer : RemoteServer {
         return util.sortDescending(ret)
     }
 
-    override fun endOperation(operation: RemoteOperation, isSuccessful: Boolean) {
-        throw NotImplementedError()
+    internal fun appendMetadata(remote: Map<String, Any>, params: Map<String, Any>, json: String) {
+        val s3 = getClient(remote, params)
+        val (bucket, key) = getPath(remote)
+        var length = 0L
+        var currentMetadata: InputStream
+        try {
+            val obj = s3.getObject(bucket, getMetadataKey(key))
+            currentMetadata = obj.objectContent
+            length = obj.objectMetadata.contentLength
+        } catch (e: AmazonS3Exception) {
+            if (e.statusCode == 404) {
+                currentMetadata = ByteArrayInputStream("".toByteArray())
+            } else {
+                throw e
+            }
+        }
+
+        val appendStream = ByteArrayInputStream("$json\n".toByteArray())
+        val stream = SequenceInputStream(currentMetadata, appendStream)
+        var objectMetadata = ObjectMetadata()
+        objectMetadata.contentLength = length + json.length + 1
+        s3.putObject(PutObjectRequest(bucket, getMetadataKey(key), stream, objectMetadata))
+    }
+
+    // There is no efficient way to do this, simply read all the commits, update the one in question, and upload
+    internal fun updateMetadata(remote: Map<String, Any>, params: Map<String, Any>, commitId: String, commit: Map<String, Any>) {
+        val s3 = getClient(remote, params)
+        val (bucket, key) = getPath(remote)
+        val originalCommits = listCommits(remote, params, emptyList())
+        val metadata = originalCommits.map {
+            if (it.first == commitId) {
+                gson.toJson(mapOf("id" to it.first, "properties" to commit))
+            } else {
+                gson.toJson(mapOf("id" to it.first, "properties" to it.second))
+            }
+        }.joinToString("\n") + "\n"
+
+        s3.putObject(bucket, getMetadataKey(key), metadata)
+    }
+
+    class S3Operation(provider: S3RemoteServer, operation: RemoteOperation) {
+        val s3: AmazonS3
+        val bucket: String
+        val key: String?
+
+        init {
+            s3 = provider.getClient(operation.remote, operation.parameters)
+            val path = provider.getPath(operation.remote, operation.commitId)
+            bucket = path.first
+            key = path.second
+        }
     }
 
     override fun startOperation(operation: RemoteOperation) {
-        throw NotImplementedError()
+        operation.data = S3Operation(this, operation)
     }
 
-    override fun syncVolume(operation: RemoteOperation, volumeName: String, volumeDescription: String, volumePath: String, scratchPath: String) {
-        throw NotImplementedError()
+    override fun endOperation(operation: RemoteOperation, isSuccessful: Boolean) {
+        // Nothing to do
+    }
+
+    override fun pullArchive(operation: RemoteOperation, volume: String, archive: File) {
+        val data = operation.data as S3Operation
+        val obj = data.s3.getObject(data.bucket, "${data.key}/$volume.tar.gz")
+        obj.objectContent.use { input ->
+            archive.outputStream().use { output ->
+                input.copyTo(output)
+            }
+        }
+    }
+
+    override fun pushArchive(operation: RemoteOperation, volume: String, archive: File) {
+        val data = operation.data as S3Operation
+        data.s3.putObject(data.bucket, "${data.key}/$volume.tar.gz", archive)
+    }
+
+    override fun pushMetadata(operation: RemoteOperation, commit: Map<String, Any>, isUpdate: Boolean) {
+        val data = operation.data as S3Operation
+        val metadata = ObjectMetadata()
+        val json = gson.toJson(mapOf("id" to operation.commitId, "properties" to commit))
+        metadata.userMetadata = mapOf(METADATA_PROP to json)
+        metadata.contentLength = 0
+        val input = ByteArrayInputStream("".toByteArray())
+        val request = PutObjectRequest(data.bucket, data.key, input, metadata)
+        data.s3.putObject(request)
+
+        if (isUpdate) {
+            updateMetadata(operation.remote, operation.parameters, operation.commitId, commit)
+        } else {
+            appendMetadata(operation.remote, operation.parameters, json)
+        }
     }
 }

--- a/server/src/main/kotlin/io/titandata/remote/s3/server/S3RemoteServer.kt
+++ b/server/src/main/kotlin/io/titandata/remote/s3/server/S3RemoteServer.kt
@@ -75,7 +75,7 @@ class S3RemoteServer : ArchiveRemote() {
     }
 
     /**
-     * Get an instance of the S3 client based on the remote configuration and parameters.
+     * Get an instance of the S3 client based on the remote configuration and parameters. Public for testing purposes.
      */
     fun getClient(remote: Map<String, Any>, parameters: Map<String, Any>): AmazonS3 {
         val accessKey = (parameters.get("accessKey") ?: remote["accessKey"]
@@ -97,9 +97,9 @@ class S3RemoteServer : ArchiveRemote() {
 
     /**
      * This function will return the (bucket, key) that identifies the given commit (or root key if no commit
-     * is specified). This takes into the account the optional path configured in the remote.
+     * is specified). This takes into the account the optional path configured in the remote. Public for testing.
      */
-    internal fun getPath(remote: Map<String, Any>, commitId: String? = null): Pair<String, String?> {
+    fun getPath(remote: Map<String, Any>, commitId: String? = null): Pair<String, String?> {
         val key = if (remote["path"] == null) {
             commitId
         } else if (commitId == null) {

--- a/server/src/test/kotlin/io/titandata/remote/s3/server/S3RemoteServerTest.kt
+++ b/server/src/test/kotlin/io/titandata/remote/s3/server/S3RemoteServerTest.kt
@@ -1,3 +1,7 @@
+/*
+ * Copyright The Titan Project Contributors.
+ */
+
 package io.titandata.remote.s3.server
 
 import com.amazonaws.auth.AWSCredentialsProvider
@@ -7,6 +11,7 @@ import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.amazonaws.services.s3.internal.AmazonS3ExceptionBuilder
 import com.amazonaws.services.s3.model.AmazonS3Exception
 import com.amazonaws.services.s3.model.ObjectMetadata
+import com.amazonaws.services.s3.model.PutObjectRequest
 import com.amazonaws.services.s3.model.S3Object
 import com.amazonaws.services.s3.model.S3ObjectInputStream
 import io.kotlintest.TestCase
@@ -17,20 +22,37 @@ import io.kotlintest.shouldNotBe
 import io.kotlintest.shouldThrow
 import io.kotlintest.specs.StringSpec
 import io.mockk.MockKAnnotations
+import io.mockk.Runs
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.impl.annotations.SpyK
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.slot
 import io.mockk.verify
+import io.titandata.remote.RemoteOperation
+import io.titandata.remote.RemoteOperationType
+import io.titandata.remote.RemoteProgress
+import java.io.BufferedReader
 import java.io.ByteArrayInputStream
+import java.io.File
 import kotlin.IllegalArgumentException
 
 class S3RemoteServerTest : StringSpec() {
 
     @SpyK
-    var client = S3RemoteServer()
+    var server = S3RemoteServer()
+
+    val operation = RemoteOperation(
+            updateProgress = { _: RemoteProgress, _: String?, _: Int? -> Unit },
+            remote = mapOf("bucket" to "bucket", "path" to "path"),
+            parameters = emptyMap(),
+            operationId = "operation",
+            commitId = "commit",
+            type = RemoteOperationType.PUSH,
+            data = null
+    )
 
     override fun beforeTest(testCase: TestCase) {
         return MockKAnnotations.init(this)
@@ -44,16 +66,16 @@ class S3RemoteServerTest : StringSpec() {
 
     init {
         "get provider returns s3" {
-            client.getProvider() shouldBe "s3"
+            server.getProvider() shouldBe "s3"
         }
 
         "validate remote succeeds with only required properties" {
-            val result = client.validateRemote(mapOf("bucket" to "bucket"))
+            val result = server.validateRemote(mapOf("bucket" to "bucket"))
             result["bucket"] shouldBe "bucket"
         }
 
         "validate remote succeeds with all properties" {
-            val result = client.validateRemote(mapOf("bucket" to "bucket", "secretKey" to "secret",
+            val result = server.validateRemote(mapOf("bucket" to "bucket", "secretKey" to "secret",
                     "accessKey" to "access", "path" to "/path", "region" to "region"))
             result["bucket"] shouldBe "bucket"
             result["secretKey"] shouldBe "secret"
@@ -64,35 +86,35 @@ class S3RemoteServerTest : StringSpec() {
 
         "validate remote fails with missing required property" {
             shouldThrow<IllegalArgumentException> {
-                client.validateRemote(emptyMap())
+                server.validateRemote(emptyMap())
             }
         }
 
         "validate remote fails with invalid property" {
             shouldThrow<IllegalArgumentException> {
-                client.validateRemote(mapOf("bucket" to "bucket", "bucketz" to "bucket"))
+                server.validateRemote(mapOf("bucket" to "bucket", "bucketz" to "bucket"))
             }
         }
 
         "validate remote fails if only access key is set" {
             shouldThrow<IllegalArgumentException> {
-                client.validateRemote(mapOf("bucket" to "bucket", "accessKey" to "access"))
+                server.validateRemote(mapOf("bucket" to "bucket", "accessKey" to "access"))
             }
         }
 
         "validate remote fails if only secret key is set" {
             shouldThrow<IllegalArgumentException> {
-                client.validateRemote(mapOf("bucket" to "bucket", "secretKey" to "secret"))
+                server.validateRemote(mapOf("bucket" to "bucket", "secretKey" to "secret"))
             }
         }
 
         "validate parameters succeeds with empty properties" {
-            val result = client.validateParameters(emptyMap())
+            val result = server.validateParameters(emptyMap())
             result.size shouldBe 0
         }
 
         "validate parameters succeeds with all properties" {
-            val result = client.validateParameters(mapOf("accessKey" to "access", "secretKey" to "secret",
+            val result = server.validateParameters(mapOf("accessKey" to "access", "secretKey" to "secret",
                     "region" to "region", "sessionToken" to "token"))
             result["accessKey"] shouldBe "access"
             result["secretKey"] shouldBe "secret"
@@ -102,45 +124,45 @@ class S3RemoteServerTest : StringSpec() {
 
         "validate parameters fails with invalid property" {
             shouldThrow<IllegalArgumentException> {
-                client.validateRemote(mapOf("foo" to "bar"))
+                server.validateRemote(mapOf("foo" to "bar"))
             }
         }
 
         "get path returns bucket" {
-            val (bucket) = client.getPath(mapOf("bucket" to "bucket"))
+            val (bucket) = server.getPath(mapOf("bucket" to "bucket"))
             bucket shouldBe "bucket"
         }
 
         "get path returns commit ID if path not specified" {
-            val result = client.getPath(mapOf("bucket" to "bucket"), "id")
+            val result = server.getPath(mapOf("bucket" to "bucket"), "id")
             result.second shouldBe "id"
         }
 
         "get path returns path if commit ID not set" {
-            val result = client.getPath(mapOf("bucket" to "bucket", "path" to "key"))
+            val result = server.getPath(mapOf("bucket" to "bucket", "path" to "key"))
             result.second shouldBe "key"
         }
 
         "get path returns path plus commit ID if set" {
-            val result = client.getPath(mapOf("bucket" to "bucket", "path" to "key"), "id")
+            val result = server.getPath(mapOf("bucket" to "bucket", "path" to "key"), "id")
             result.second shouldBe "key/id"
         }
 
         "get client fails with no access key" {
             shouldThrow<IllegalArgumentException> {
-                client.getClient(mapOf("secretKey" to "secretKey", "region" to "region"), emptyMap())
+                server.getClient(mapOf("secretKey" to "secretKey", "region" to "region"), emptyMap())
             }
         }
 
         "get client fails with no secret key" {
             shouldThrow<IllegalArgumentException> {
-                client.getClient(mapOf("accessKey" to "accessKey", "region" to "region"), emptyMap())
+                server.getClient(mapOf("accessKey" to "accessKey", "region" to "region"), emptyMap())
             }
         }
 
         "get client fails with no region" {
             shouldThrow<IllegalArgumentException> {
-                client.getClient(mapOf("accessKey" to "accessKey", "secretKey" to "secretKey"), emptyMap())
+                server.getClient(mapOf("accessKey" to "accessKey", "secretKey" to "secretKey"), emptyMap())
             }
         }
 
@@ -153,7 +175,7 @@ class S3RemoteServerTest : StringSpec() {
             every { builder.withCredentials(capture(slot)) } returns builder
             every { builder.build() } returns mockk()
 
-            client.getClient(mapOf("accessKey" to "accessKey", "secretKey" to "secretKey", "region" to "region"), emptyMap())
+            server.getClient(mapOf("accessKey" to "accessKey", "secretKey" to "secretKey", "region" to "region"), emptyMap())
 
             val creds = slot.captured
             creds.credentials.awsAccessKeyId shouldBe "accessKey"
@@ -173,7 +195,7 @@ class S3RemoteServerTest : StringSpec() {
             every { builder.withCredentials(capture(slot)) } returns builder
             every { builder.build() } returns mockk()
 
-            client.getClient(mapOf("accessKey" to "accessKey", "secretKey" to "secretKey", "region" to "region"), mapOf("sessionToken" to "token"))
+            server.getClient(mapOf("accessKey" to "accessKey", "secretKey" to "secretKey", "region" to "region"), mapOf("sessionToken" to "token"))
 
             val creds = slot.captured
             creds.credentials.awsAccessKeyId shouldBe "accessKey"
@@ -188,8 +210,8 @@ class S3RemoteServerTest : StringSpec() {
         "get commit fails if no user metadata present" {
             val s3: AmazonS3Client = mockk()
             every { s3.getObjectMetadata(any(), any()) } returns ObjectMetadata()
-            every { client.getClient(any(), any()) } returns s3
-            val result = client.getCommit(mapOf("bucket" to "bucket", "path" to "path"), emptyMap(), "id")
+            every { server.getClient(any(), any()) } returns s3
+            val result = server.getCommit(mapOf("bucket" to "bucket", "path" to "path"), emptyMap(), "id")
             result shouldBe null
             verify {
                 s3.getObjectMetadata("bucket", "path/id")
@@ -201,8 +223,8 @@ class S3RemoteServerTest : StringSpec() {
             metadata.userMetadata = mapOf()
             val s3: AmazonS3Client = mockk()
             every { s3.getObjectMetadata(any(), any()) } returns metadata
-            every { client.getClient(any(), any()) } returns s3
-            val result = client.getCommit(mapOf("bucket" to "bucket", "path" to "path"), emptyMap(), "id")
+            every { server.getClient(any(), any()) } returns s3
+            val result = server.getCommit(mapOf("bucket" to "bucket", "path" to "path"), emptyMap(), "id")
             result shouldBe null
         }
 
@@ -211,8 +233,8 @@ class S3RemoteServerTest : StringSpec() {
             metadata.userMetadata = mapOf("io.titan-data" to "{}")
             val s3: AmazonS3Client = mockk()
             every { s3.getObjectMetadata(any(), any()) } returns metadata
-            every { client.getClient(any(), any()) } returns s3
-            val result = client.getCommit(mapOf("bucket" to "bucket", "path" to "path"), emptyMap(), "id")
+            every { server.getClient(any(), any()) } returns s3
+            val result = server.getCommit(mapOf("bucket" to "bucket", "path" to "path"), emptyMap(), "id")
             result shouldBe null
         }
 
@@ -221,8 +243,8 @@ class S3RemoteServerTest : StringSpec() {
             metadata.userMetadata = mapOf("io.titan-data" to "{\"properties\":{\"a\":\"b\"}}")
             val s3: AmazonS3Client = mockk()
             every { s3.getObjectMetadata(any(), any()) } returns metadata
-            every { client.getClient(any(), any()) } returns s3
-            val result = client.getCommit(mapOf("bucket" to "bucket", "path" to "path"), emptyMap(), "id")
+            every { server.getClient(any(), any()) } returns s3
+            val result = server.getCommit(mapOf("bucket" to "bucket", "path" to "path"), emptyMap(), "id")
             result shouldNotBe null
             result!!["a"] shouldBe "b"
         }
@@ -232,26 +254,26 @@ class S3RemoteServerTest : StringSpec() {
             val exceptionBuilder = AmazonS3ExceptionBuilder()
             exceptionBuilder.statusCode = 404
             every { s3.getObjectMetadata(any(), any()) } throws exceptionBuilder.build()
-            every { client.getClient(any(), any()) } returns s3
-            val result = client.getCommit(mapOf("bucket" to "bucket", "path" to "path"), emptyMap(), "id")
+            every { server.getClient(any(), any()) } returns s3
+            val result = server.getCommit(mapOf("bucket" to "bucket", "path" to "path"), emptyMap(), "id")
             result shouldBe null
         }
 
         "get commit fails on other exceptions" {
             val s3: AmazonS3Client = mockk()
             every { s3.getObjectMetadata(any(), any()) } throws AmazonS3ExceptionBuilder().build()
-            every { client.getClient(any(), any()) } returns s3
+            every { server.getClient(any(), any()) } returns s3
             shouldThrow<AmazonS3Exception> {
-                client.getCommit(mapOf("bucket" to "bucket", "path" to "path"), emptyMap(), "id")
+                server.getCommit(mapOf("bucket" to "bucket", "path" to "path"), emptyMap(), "id")
             }
         }
 
         "get metadata key returns titan if path is null" {
-            client.getMetadataKey(null) shouldBe "titan"
+            server.getMetadataKey(null) shouldBe "titan"
         }
 
         "get metadata key returns path directory if set" {
-            client.getMetadataKey("path") shouldBe "path/titan"
+            server.getMetadataKey("path") shouldBe "path/titan"
         }
 
         "get metadata content succeeds" {
@@ -259,8 +281,8 @@ class S3RemoteServerTest : StringSpec() {
             every { obj.objectContent } returns S3ObjectInputStream(ByteArrayInputStream("test".toByteArray()), null)
             val s3: AmazonS3Client = mockk()
             every { s3.getObject(any<String>(), any<String>()) } returns obj
-            every { client.getClient(any(), any()) } returns s3
-            val result = client.getMetadataContent(mapOf("bucket" to "bucket", "path" to "path"), emptyMap())
+            every { server.getClient(any(), any()) } returns s3
+            val result = server.getMetadataContent(mapOf("bucket" to "bucket", "path" to "path"), emptyMap())
             result.bufferedReader().readText() shouldBe "test"
             verify {
                 s3.getObject("bucket", "path/titan")
@@ -272,34 +294,192 @@ class S3RemoteServerTest : StringSpec() {
             exceptionBuilder.statusCode = 404
             val s3: AmazonS3Client = mockk()
             every { s3.getObject(any<String>(), any<String>()) } throws exceptionBuilder.build()
-            every { client.getClient(any(), any()) } returns s3
-            val result = client.getMetadataContent(mapOf("bucket" to "bucket", "path" to "path"), emptyMap())
+            every { server.getClient(any(), any()) } returns s3
+            val result = server.getMetadataContent(mapOf("bucket" to "bucket", "path" to "path"), emptyMap())
             result.bufferedReader().readText() shouldBe ""
         }
 
         "get metadata content fails on unknown exception" {
             val s3: AmazonS3Client = mockk()
             every { s3.getObject(any<String>(), any<String>()) } throws AmazonS3ExceptionBuilder().build()
-            every { client.getClient(any(), any()) } returns s3
+            every { server.getClient(any(), any()) } returns s3
             shouldThrow<AmazonS3Exception> {
-                client.getMetadataContent(mapOf("bucket" to "bucket", "path" to "path"), emptyMap())
+                server.getMetadataContent(mapOf("bucket" to "bucket", "path" to "path"), emptyMap())
             }
         }
 
         "list commits returns an empty list" {
-            every { client.getMetadataContent(any(), any()) } returns ByteArrayInputStream("".toByteArray())
-            val result = client.listCommits(emptyMap(), emptyMap(), emptyList())
+            every { server.getMetadataContent(any(), any()) } returns ByteArrayInputStream("".toByteArray())
+            val result = server.listCommits(emptyMap(), emptyMap(), emptyList())
             result.size shouldBe 0
         }
 
         "list commits filters result" {
-            every { client.getMetadataContent(any(), any()) } returns ByteArrayInputStream(
+            every { server.getMetadataContent(any(), any()) } returns ByteArrayInputStream(
                     arrayOf("{\"id\":\"a\",\"properties\":{\"tags\":{\"c\":\"d\"}}}",
                             "{\"id\":\"b\",\"properties\":{}}")
                             .joinToString("\n").toByteArray())
-            val result = client.listCommits(emptyMap(), emptyMap(), listOf("c" to null))
+            val result = server.listCommits(emptyMap(), emptyMap(), listOf("c" to null))
             result.size shouldBe 1
             result[0].first shouldBe "a"
+        }
+
+        "append metadata succeeds" {
+            val obj: S3Object = mockk()
+            val currentContent = "{\"id\":\"a\",\"properties\":{}}\n"
+            every { obj.objectContent } returns S3ObjectInputStream(ByteArrayInputStream(currentContent.toByteArray()), null)
+            val metadata = ObjectMetadata()
+            metadata.contentLength = currentContent.length.toLong()
+            every { obj.objectMetadata } returns metadata
+            val s3: AmazonS3Client = mockk()
+            every { s3.getObject(any<String>(), any<String>()) } returns obj
+            every { server.getClient(any(), any()) } returns s3
+            val slot = slot<PutObjectRequest>()
+            every { s3.putObject(capture(slot)) } returns mockk()
+
+            server.appendMetadata(mapOf("bucket" to "bucket", "path" to "path"), emptyMap(),
+                    "{\"id\":\"b\",\"properties\":{})")
+            slot.captured.bucketName shouldBe "bucket"
+            slot.captured.key shouldBe "path/titan"
+            val newContent = slot.captured.inputStream.bufferedReader().use(BufferedReader::readText)
+            newContent shouldBe "{\"id\":\"a\",\"properties\":{}}\n{\"id\":\"b\",\"properties\":{})\n"
+        }
+
+        "append metadata treats 404 as empty" {
+            val s3: AmazonS3Client = mockk()
+            val exceptionBuilder = AmazonS3ExceptionBuilder()
+            exceptionBuilder.statusCode = 404
+            every { s3.getObject(any<String>(), any<String>()) } throws exceptionBuilder.build()
+            every { server.getClient(any(), any()) } returns s3
+            val slot = slot<PutObjectRequest>()
+            every { s3.putObject(capture(slot)) } returns mockk()
+
+            server.appendMetadata(mapOf("bucket" to "bucket", "path" to "path"), emptyMap(),
+                    "{\"id\":\"b\",\"properties\":{}}")
+            slot.captured.bucketName shouldBe "bucket"
+            slot.captured.key shouldBe "path/titan"
+            val newContent = slot.captured.inputStream.bufferedReader().use(BufferedReader::readText)
+            newContent shouldBe "{\"id\":\"b\",\"properties\":{}}\n"
+        }
+
+        "append metadata passes other exceptions through" {
+            val s3: AmazonS3Client = mockk()
+            val exceptionBuilder = AmazonS3ExceptionBuilder()
+            exceptionBuilder.statusCode = 403
+            every { s3.getObject(any<String>(), any<String>()) } throws exceptionBuilder.build()
+            every { server.getClient(any(), any()) } returns s3
+
+            shouldThrow<AmazonS3Exception> {
+                server.appendMetadata(mapOf("bucket" to "bucket", "path" to "path"), emptyMap(),
+                        "{\"id\":\"b\",\"properties\":{}}")
+            }
+        }
+
+        "update metadata replaces content" {
+            val s3: AmazonS3Client = mockk()
+            every { server.getClient(any(), any()) } returns s3
+            every { server.listCommits(any(), any(), any()) } returns listOf(
+                "a" to emptyMap(), "b" to emptyMap())
+            every { s3.putObject(any<String>(), any<String>(), any<String>()) } returns mockk()
+
+            server.updateMetadata(mapOf("bucket" to "bucket", "path" to "path"), emptyMap(),
+                    "a", mapOf("x" to "y"))
+
+            verify {
+                s3.putObject("bucket", "path/titan",
+                        "{\"id\":\"a\",\"properties\":{\"x\":\"y\"}}\n{\"id\":\"b\",\"properties\":{}}\n")
+            }
+        }
+
+        "start operation sets data object" {
+            every { server.getClient(any(), any()) } returns mockk()
+            server.startOperation(operation)
+            val data = operation.data as S3RemoteServer.S3Operation
+            data.bucket shouldBe "bucket"
+            data.key shouldBe "path/commit"
+        }
+
+        "end operation does nothing" {
+            server.endOperation(operation, true)
+        }
+
+        "pull archive writes contents to file" {
+            val s3: AmazonS3Client = mockk()
+            every { server.getClient(any(), any()) } returns s3
+            operation.data = S3RemoteServer.S3Operation(
+                    provider = server,
+                    operation = operation)
+            val obj: S3Object = mockk()
+            every { s3.getObject(any<String>(), any<String>()) } returns obj
+            every { obj.objectContent } returns S3ObjectInputStream(ByteArrayInputStream("test".toByteArray()), null)
+
+            val file = createTempFile()
+            server.pullArchive(operation, "volume", file)
+
+            val contents = file.readText()
+            contents shouldBe "test"
+
+            verify {
+                s3.getObject("bucket", "path/commit/volume.tar.gz")
+            }
+        }
+
+        "push archive succeeds" {
+            val s3: AmazonS3Client = mockk()
+            every { server.getClient(any(), any()) } returns s3
+            operation.data = S3RemoteServer.S3Operation(
+                    provider = server,
+                    operation = operation)
+            every { s3.putObject(any<String>(), any<String>(), any<File>()) } returns mockk()
+
+            val file = createTempFile()
+            server.pushArchive(operation, "volume", file)
+
+            verify {
+                s3.putObject("bucket", "path/commit/volume.tar.gz", any<File>())
+            }
+        }
+
+        "push metadata with update calls update metadata" {
+            val s3: AmazonS3Client = mockk()
+            every { server.getClient(any(), any()) } returns s3
+            operation.data = S3RemoteServer.S3Operation(
+                    provider = server,
+                    operation = operation)
+            val slot = slot<PutObjectRequest>()
+            every { s3.putObject(capture(slot)) } returns mockk()
+            every { server.updateMetadata(any(), any(), any(), any()) } just Runs
+
+            server.pushMetadata(operation, mapOf("a" to "b"), true)
+
+            slot.captured.bucketName shouldBe "bucket"
+            slot.captured.key shouldBe "path/commit"
+            slot.captured.metadata.userMetadata["io.titan-data"] shouldBe "{\"id\":\"commit\",\"properties\":{\"a\":\"b\"}}"
+
+            verify {
+                server.updateMetadata(any(), any(), "commit", mapOf("a" to "b"))
+            }
+        }
+
+        "push metadata without update calls append metadata" {
+            val s3: AmazonS3Client = mockk()
+            every { server.getClient(any(), any()) } returns s3
+            operation.data = S3RemoteServer.S3Operation(
+                    provider = server,
+                    operation = operation)
+            val slot = slot<PutObjectRequest>()
+            every { s3.putObject(capture(slot)) } returns mockk()
+            every { server.appendMetadata(any(), any(), any()) } just Runs
+
+            server.pushMetadata(operation, mapOf("a" to "b"), false)
+
+            slot.captured.bucketName shouldBe "bucket"
+            slot.captured.key shouldBe "path/commit"
+            slot.captured.metadata.userMetadata["io.titan-data"] shouldBe "{\"id\":\"commit\",\"properties\":{\"a\":\"b\"}}"
+
+            verify {
+                server.appendMetadata(any(), any(), "{\"id\":\"commit\",\"properties\":{\"a\":\"b\"}}")
+            }
         }
     }
 }

--- a/server/src/test/kotlin/io/titandata/remote/s3/server/S3RemoteServerTest.kt
+++ b/server/src/test/kotlin/io/titandata/remote/s3/server/S3RemoteServerTest.kt
@@ -50,6 +50,7 @@ class S3RemoteServerTest : StringSpec() {
             parameters = emptyMap(),
             operationId = "operation",
             commitId = "commit",
+            commit = null,
             type = RemoteOperationType.PUSH,
             data = null
     )


### PR DESCRIPTION
## Proposed Changes

This adds all the interfaces required by the new remote SDK. While I was here, I also cleaned up some copyright stuff and made it so you could link to libraries in your local maven repository.

## Testing

`gradle build` and verified coverage. Also ran all tests in `titan-server` (including endtoend tests) with new remote.